### PR TITLE
Change World Surface to be a series of sub-surfaces to allow for bigger maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Uncivilization.egg-info/
+Uncivilization/__pycache__/

--- a/Uncivilization/Camera.py
+++ b/Uncivilization/Camera.py
@@ -201,7 +201,7 @@ class Camera:
                 prev_w += w_sub_camera
                 prev_ws.append(prev_w)
 
-            ctlx = cbrx
+                ctlx = cbrx
             wc = xf
 
         self.surface.blits([[surfs[i],(prev_ws[i],0)] for i in range(len(surfs))])

--- a/Uncivilization/Camera.py
+++ b/Uncivilization/Camera.py
@@ -6,7 +6,9 @@ INV_S3 = S3 * (1 / 3)
 
 
 class Camera:
-    def __init__(self, hex_asset_size, w_scr, h_scr, true_rows, true_cols, rows, cols, n_max=14, n_min=4):
+    def __init__(
+        self, hex_asset_size, w_scr, h_scr, true_rows, true_cols, rows, cols, n_max=14, n_min=4
+    ):
         self.n_min = n_min
         self.n_max = n_max
         self.hex_asset_size = hex_asset_size
@@ -28,16 +30,17 @@ class Camera:
         self.reverse = False
         self.zoom_level = 1
 
-        w_world, h_world, d_from_bottom, d_from_top = self.determine_section_size(true_rows,true_cols)
-        w_play, h_play, _ , _ = self.determine_section_size(rows,cols)
+        w_world, h_world, d_from_bottom, d_from_top = self.determine_section_size(
+            true_rows, true_cols
+        )
+        w_play, h_play, _, _ = self.determine_section_size(rows, cols)
 
         self.world_size = (w_world, h_world)
-        self.player_world_size = (w_play,h_play)
+        self.player_world_size = (w_play, h_play)
         self.d_from_bottom = d_from_bottom
         self.d_from_top = d_from_top
         self.WORLD_SURFACES = self.initialize_world_surfaces()
         self.AXIAL_ORIGIN_PIXEL = None
-
 
     def determine_section_size(self, rows, cols):
         rows_bot = -(-rows // 2) if rows % 2 == 0 else -(-rows // 2) - 1
@@ -48,19 +51,18 @@ class Camera:
         h = d_from_top + d_from_bottom
         return w, h, d_from_bottom, d_from_top
 
-
     def initialize_world_surfaces(self):
-        w,h = self.world_size
+        w, h = self.world_size
         size = w * h
 
         # if we get random float errors, its probably because of this :)
         ww = int(w)
 
         # All determined emperically for sanity check
-        # they are indeed diff by a factor of 1024 exactly        
+        # they are indeed diff by a factor of 1024 exactly
         k_gb = 3.725290298461914e-09
         k_mb = 3.814697265625e-06
-        #k_kb = 3.90625e-03
+        # k_kb = 3.90625e-03
 
         est_mem_gb = k_gb * size
         if est_mem_gb >= 2:
@@ -74,9 +76,9 @@ class Camera:
         w_last = ww % w_sub
         n_sub = ww // w_sub
 
-        surfaces = [pg.Surface((w_sub,h)) for _ in range(n_sub)]
+        surfaces = [pg.Surface((w_sub, h)) for _ in range(n_sub)]
         if w_last > 0:
-            surfaces.append(pg.Surface((w_last,h)))
+            surfaces.append(pg.Surface((w_last, h)))
         return surfaces
 
     def get_surface_center(self):
@@ -115,13 +117,17 @@ class Camera:
     def update_center(self, cen):
         cx, cy = cen
 
-        w, h = self.surface.get_size()
+        cam_w, cam_h = self.surface.get_size()
         world_size = self.world_size
+        # playable_world_size = self.player_world_size
+
+        w, h = world_size
+
         origin = self.AXIAL_ORIGIN_PIXEL
 
-        max_x = world_size[0]
+        max_x = w
         min_x = 0
-        max_y = world_size[1]
+        max_y = h
         min_y = 0
 
         br, tl = self.get_bottom_right_and_top_left(center=cen)
@@ -137,19 +143,19 @@ class Camera:
 
         # # Overshot right
         if br_worldx > max_x:
-            cx_worldx = max_x - w / 2
+            cx_worldx = max_x - cam_w / 2
 
         # # Overshot left
         if tl_worldx < min_x:
-            cx_worldx = min_x + w / 2
+            cx_worldx = min_x + cam_w / 2
 
         # # Overshot up
         if tl_worldy < min_y:
-            cy_worldy = min_y + h / 2
+            cy_worldy = min_y + cam_h / 2
 
         # # Overshot down
         if br_worldy > max_y:
-            cy_worldy = max_y - h / 2
+            cy_worldy = max_y - cam_h / 2
 
         cx = cx_worldx - origin[0]
         cy = cy_worldy - origin[1]
@@ -189,17 +195,17 @@ class Camera:
         for surface in world:
             w_surf, _ = surface.get_size()
             _, h_camera = self.surface.get_size()
-            
+
             xf = wc + w_surf
-            cbrx = min(xf,brx)
+            cbrx = min(xf, brx)
             if ctlx != cbrx and ctlx <= xf:
                 tlx_p = ctlx - wc
-                brx_p = min(w_surf, brx-wc)
+                brx_p = min(w_surf, brx - wc)
 
                 w_sub_camera = brx_p - tlx_p
-                proper_rect = pg.Rect((tlx_p, tly),(w_sub_camera,h_camera))
+                proper_rect = pg.Rect((tlx_p, tly), (w_sub_camera, h_camera))
                 sub_surf = surface.subsurface(proper_rect)
-                
+
                 surfs.append(sub_surf)
                 prev_w += w_sub_camera
                 prev_ws.append(prev_w)
@@ -207,7 +213,7 @@ class Camera:
                 ctlx = cbrx
             wc = xf
 
-        self.surface.blits([[surfs[i],(prev_ws[i],0)] for i in range(len(surfs))])
+        self.surface.blits([[surfs[i], (prev_ws[i], 0)] for i in range(len(surfs))])
 
         # proper_rect = pg.Rect((tlx, tly), self.surface.get_size())
         # new_surface = world.subsurface(proper_rect)

--- a/Uncivilization/Camera.py
+++ b/Uncivilization/Camera.py
@@ -39,7 +39,7 @@ class Camera:
 
         self.world_size = (w_world, h_world)
         self.WORLD_SURFACE = pg.Surface(self.world_size)
-        self.AXIAL_ORIGIN = None
+        self.AXIAL_ORIGIN_PIXEL = None
 
     def get_surface_center(self):
         w, h = self.surface.get_size()
@@ -83,7 +83,7 @@ class Camera:
 
         w, h = self.surface.get_size()
         world_size = self.world_size
-        origin = self.AXIAL_ORIGIN
+        origin = self.AXIAL_ORIGIN_PIXEL
 
         max_x = world_size[0]
         min_x = 0
@@ -135,7 +135,7 @@ class Camera:
         self.update_center(self.center, game)  # probably not necessary
 
     def update_display_as_world_section(self):
-        origin = self.AXIAL_ORIGIN
+        origin = self.AXIAL_ORIGIN_PIXEL
         world = self.WORLD_SURFACE
 
         _, tl = self.get_bottom_right_and_top_left()

--- a/Uncivilization/GameObject.py
+++ b/Uncivilization/GameObject.py
@@ -1,9 +1,4 @@
 import pygame as pg
-import numpy as np
-import copy
-import json
-import pickle
-import random
 
 # from Uncivilization.Camera import *
 from Uncivilization.MapNameToInstructions import *
@@ -15,7 +10,7 @@ NUM_CHARACTERS = 6
 class GameObject:
     def __init__(self, player_input, game_state, renderer, audio_mixer):
         self.eps = 0.005
-        self.dt = 2 ** 31
+        self.dt = 2**31
         self.TARGET_FPS = 60
         self.MAX_FPS = 60
         self.drawDiagnostic = False
@@ -46,12 +41,12 @@ class PlayerInput:
 class GameState:
     def __init__(self):
         self.isPaused = False
-        # TODO, this breaks for low rows/cols 
+        # TODO, this breaks for low rows/cols
         # (proportial to window_size)
         # Should support n_min and corresponding ratio
-        self.rows = 26
-        self.cols = 44
-        # that being said, for refernce civ 6 tiniest 
+        self.rows = 66
+        self.cols = 200
+        # that being said, for refernce civ 6 tiniest
         # map is 44x26 and the largest is 106x66 columns
         self.grid_size = (self.rows, self.cols)
         self.board = {}
@@ -109,7 +104,6 @@ class Renderer:
         self.settingsBoxFormatting = self.setSettingsBoxFormatting()
         self.settingsMenuBoxes = self.getSettingsMenuBoxes()
         self.mapSelectRedraw = None
-
 
     def getMainMenuBoxes(
         self,
@@ -254,7 +248,7 @@ class Renderer:
                 (rows, cols), (x0, y0), (w_takeup, h_takeup), (row_num, col_num), x_buff=0
             )
             desc_rects.append([surface, rect])
-        
+
         self.settingsBoxFormatting["display_surround_box"] = desc_rects[0]
 
         return desc_rects
@@ -270,7 +264,7 @@ class Renderer:
         arrow_left = self.assets["initial_screen"]["left_arrow.png"]
 
         arrow_size = arrow_right.get_size()
-        
+
         largest_rect_width = formatting_info["largest_value_rect_width"]
         largest_rect_height = formatting_info["largest_value_rect_height"]
 
@@ -281,11 +275,10 @@ class Renderer:
             arrow_left = pg.transform.flip(arrow_right, True, False)
             self.assets["initial_screen"]["left_arrow.png"] = arrow_left
 
-        
         first_setting_box = formatting_info["display_surround_box"]
 
         x0 = first_setting_box[1].bottomright[0] + w / 4
-        y0 = first_setting_box[1].topleft[1] - max(w//50,1)
+        y0 = first_setting_box[1].topleft[1] - max(w // 50, 1)
 
         rows = formatting_info["rows"]
         cols = 1
@@ -304,7 +297,7 @@ class Renderer:
                 (rows, cols), (x0, y0), (w_takeup, h_takeup), (row_num, col_num), x_buff=0
             )
             interact_rects.append([TextSurf, rect])
-        
+
         ref_rect = interact_rects[0][1]
 
         x0 = ref_rect.bottomright[0]
@@ -313,19 +306,18 @@ class Renderer:
         x0 -= size[0]
         nw = size[0]
         nh = ref_rect.height
-        new_rect = pg.Rect((x0,y0),(nw,nh))
+        new_rect = pg.Rect((x0, y0), (nw, nh))
 
-        interact_rects.append([arrow_right,new_rect])
+        interact_rects.append([arrow_right, new_rect])
 
         x0 = ref_rect.topleft[0]
         y0 = ref_rect.topleft[1]
         size = arrow_left.get_size()
         nw = size[0]
         nh = ref_rect.height
-        new_rect = pg.Rect((x0,y0),(nw,nh))
+        new_rect = pg.Rect((x0, y0), (nw, nh))
 
-        interact_rects.append([arrow_left,new_rect])
-
+        interact_rects.append([arrow_left, new_rect])
 
         return interact_rects
 
@@ -339,7 +331,7 @@ class Renderer:
         descriptors = self.settings_Descriptors()
         interactables = self.settings_Interactables()
 
-        descriptors.insert(0,title_box_info)
+        descriptors.insert(0, title_box_info)
 
         return [descriptors, interactables]
 

--- a/Uncivilization/GameObject.py
+++ b/Uncivilization/GameObject.py
@@ -46,8 +46,13 @@ class PlayerInput:
 class GameState:
     def __init__(self):
         self.isPaused = False
-        self.rows = 25
-        self.cols = 50
+        # TODO, this breaks for low rows/cols 
+        # (proportial to window_size)
+        # Should support n_min and corresponding ratio
+        self.rows = 26
+        self.cols = 44
+        # that being said, for refernce civ 6 tiniest 
+        # map is 44x26 and the largest is 106x66 columns
         self.grid_size = (self.rows, self.cols)
         self.board = {}
         self.inMainMenu = True

--- a/Uncivilization/GameObject.py
+++ b/Uncivilization/GameObject.py
@@ -21,7 +21,7 @@ class GameObject:
         self.AudioMixer = audio_mixer
 
     def calc_fps(self):
-        return 1 / self.dt
+        return 1 / self.dt if self.dt != 0 else np.inf
 
 
 class PlayerInput:
@@ -42,15 +42,20 @@ class GameState:
     def __init__(self):
         self.isPaused = False
         # TODO, this breaks for low rows/cols
-        # (proportial to window_size)
-        # Should support n_min and corresponding ratio
-        self.playable_rows = 3
-        self.playable_cols = 3
-        self.rows = max(self.playable_rows, 10)
-        self.cols = max(self.playable_cols, 15)
+        # ^ default rows <-> assume blank tiles
+        # fixes this, need to make camera not
+        # look horrible for low tiles though,
+        # that being said a 44 x 26 map
+        # works fine as is
+        default_rows = 10
+        default_cols = 20
+        self.playable_rows = 26
+        self.playable_cols = 44
+        self.rows = max(self.playable_rows, default_rows)
+        self.cols = max(self.playable_cols, default_cols)
         # that being said, for refernce civ 6 tiniest
         # map is 44x26 and the largest is 106x66 columns
-        self.playable_grid_size = (self.playable_rows,self.playable_cols)
+        self.playable_grid_size = (self.playable_rows, self.playable_cols)
         self.grid_size = (self.rows, self.cols)
         self.board = {}
         self.inMainMenu = True

--- a/Uncivilization/GameObject.py
+++ b/Uncivilization/GameObject.py
@@ -44,10 +44,13 @@ class GameState:
         # TODO, this breaks for low rows/cols
         # (proportial to window_size)
         # Should support n_min and corresponding ratio
-        self.rows = 66
-        self.cols = 200
+        self.playable_rows = 3
+        self.playable_cols = 3
+        self.rows = max(self.playable_rows, 10)
+        self.cols = max(self.playable_cols, 15)
         # that being said, for refernce civ 6 tiniest
         # map is 44x26 and the largest is 106x66 columns
+        self.playable_grid_size = (self.playable_rows,self.playable_cols)
         self.grid_size = (self.rows, self.cols)
         self.board = {}
         self.inMainMenu = True

--- a/Uncivilization/HandleDraw.py
+++ b/Uncivilization/HandleDraw.py
@@ -178,7 +178,7 @@ def init_world_render(game):
     )
     origin_x = w_world - (cols_right + 0.5) * cam.hex_asset_size[0]
     origin_y = d_from_bottom
-    cam.AXIAL_ORIGIN = (origin_x, origin_y)
+    cam.AXIAL_ORIGIN_PIXEL = (origin_x, origin_y)
 
     for tile in board.values():
         tile.draw_tile_images_to_world(game)

--- a/Uncivilization/HandleDraw.py
+++ b/Uncivilization/HandleDraw.py
@@ -109,7 +109,7 @@ def drawSettingsMenu(game):
 
         pg.draw.rect(screen, (100, 100, 100), rect, width=3)
         screen.blit(surf, (centerx, centery))
-         
+
     for box_info in boxes_interact:
         surf, rect = box_info
         sx, sy = surf.get_size()
@@ -118,9 +118,8 @@ def drawSettingsMenu(game):
         centerx -= sx // 2
         centery -= sy // 2
 
-        #pg.draw.rect(screen, (100, 100, 100), rect, width=3)
+        # pg.draw.rect(screen, (100, 100, 100), rect, width=3)
         screen.blit(surf, (centerx, centery))
-
 
     pg.display.update()
     diagnosticsDraw(game) if game.drawDiagnostic else cleanDiagnosticDraw(game)
@@ -163,7 +162,6 @@ def distance_to_extrema_rows(n_rows, size):
 def init_world_render(game):
     t_load = time.time()
     gamestate = game.GameState
-    rows, cols = gamestate.grid_size
 
     board = gamestate.board
     rend = game.Renderer
@@ -182,12 +180,15 @@ def init_world_render(game):
 
     for tile in board.values():
         tile.draw_tile_images_to_world(game)
-        tile.draw_coords(game, ctype="both")
+        #tile.draw_coords(game, ctype="both")
 
     dt = time.time() - t_load
     dt = format(dt, "0.2f")
-    byte_size_row = cam.WORLD_SURFACE.get_pitch()
-    byte_size = byte_size_row * cam.WORLD_SURFACE.get_size()[1]
+    byte_size = 0
+    for surface in cam.WORLD_SURFACES:
+        byte_size_row = surface.get_pitch()
+        byte_size += byte_size_row * surface.get_size()[1]
+    
     byte_size /= 1024 * 1024 * 1024
     byte_size = format(byte_size, "0.2f")
     print(f"Finished initializing world in {dt}s.\nIt is ~{byte_size} GB (using pitch * height)")

--- a/Uncivilization/HandleDraw.py
+++ b/Uncivilization/HandleDraw.py
@@ -186,7 +186,7 @@ def init_world_render(game):
     for surface in cam.WORLD_SURFACES:
         byte_size_row = surface.get_pitch()
         byte_size += byte_size_row * surface.get_size()[1]
-    
+
     byte_size /= 1024 * 1024 * 1024
     byte_size = format(byte_size, "0.2f")
     print(f"Finished initializing world in {dt}s.\nIt is ~{byte_size} GB (using pitch * height)")

--- a/Uncivilization/HandleDraw.py
+++ b/Uncivilization/HandleDraw.py
@@ -1,7 +1,5 @@
 import pygame as pg
 import numpy as np
-import random
-import sys
 import time
 
 from Uncivilization.Hex import *
@@ -180,7 +178,7 @@ def init_world_render(game):
 
     for tile in board.values():
         tile.draw_tile_images_to_world(game)
-        #tile.draw_coords(game, ctype="both")
+        tile.draw_coords(game, ctype="both")
 
     dt = time.time() - t_load
     dt = format(dt, "0.2f")

--- a/Uncivilization/HandleInputs.py
+++ b/Uncivilization/HandleInputs.py
@@ -136,7 +136,7 @@ def basicUserInputLogic(game):
         diff = (-scale_factor * diffx, -scale_factor * diffy)
         # diff = (-diffx/scale_factor,-diffy/scale_factor)
 
-        cam.add_to_center(diff, game)
+        cam.add_to_center(diff)
 
         rend.full_redraw = True
         if inputs.lc_held1 == inputs.lc_held0:

--- a/Uncivilization/Hex.py
+++ b/Uncivilization/Hex.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pygame as pg
 
 ONE_THIRD = 1 / 3
 S3 = np.sqrt(3)
@@ -169,7 +168,7 @@ class Hex:
 
     def get_edge(self, center, size, indeces):
         start, end = indeces
-        return get_corner(center, size, start), get_corner(center, size, end)
+        return self.get_corner(center, size, start), self.get_corner(center, size, end)
 
     def draw_coords(self, game, ctype="axial"):
         q, r = self.v
@@ -194,7 +193,7 @@ class Hex:
 
         TextSurf = render.coordText.render(coord_s, False, (1, 1, 1))
         text_rect = TextSurf.get_rect(center=(x, y))
-        cam.WORLD_SURFACE.blit(TextSurf, text_rect)
+        cam.WORLD_SURFACES.blit(TextSurf, text_rect)
 
     def get_image_for_display(self, game, img="dark_blue_hex_and_border.png"):
         r = game.Renderer
@@ -207,13 +206,13 @@ class Hex:
 
         return loaded_image, dest
 
-    def draw_tile_images_to_display(self, game):
-        rend = game.Renderer
-        camera = rend.camera
-        display = camera.surface
-        for image in self.images:
-            asset, dest = self.get_image_for_display(game, img=image)
-            display.blit(asset, dest)
+    # def draw_tile_images_to_display(self, game):
+    #     rend = game.Renderer
+    #     camera = rend.camera
+    #     display = camera.surface
+    #     for image in self.images:
+    #         asset, dest = self.get_image_for_display(game, img=image)
+    #         display.blit(asset, dest)
 
     def get_image_for_world(self, game, img="dark_blue_hex_and_border.png"):
         r = game.Renderer
@@ -234,6 +233,20 @@ class Hex:
     def draw_tile_images_to_world(self, game):
         rend = game.Renderer
         camera = rend.camera
+        surfaces = camera.WORLD_SURFACES
+
         for image in self.images:
-            asset, dest = self.get_image_for_world(game, img=image)
-            camera.WORLD_SURFACE.blit(asset, dest)
+            img, tl = self.get_image_for_world(game,img=image)
+            tlx,tly = tl
+            wc = 0
+            cx = tlx
+            for surface in surfaces:
+                w_surf, h_surf = surface.get_size()
+                xf = wc + w_surf
+                if cx <= xf:
+                    tlx_p = cx - wc
+                    surface.blit(img,(tlx_p,tly))
+                wc = xf
+
+        #asset_dest_pairs = [self.get_image_for_world(game,img=image) for image in self.images]
+        #camera.WORLD_SURFACES.blits(asset_dest_pairs)

--- a/Uncivilization/Hex.py
+++ b/Uncivilization/Hex.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pygame as pg
 
 ONE_THIRD = 1 / 3
 S3 = np.sqrt(3)
@@ -193,7 +194,33 @@ class Hex:
 
         TextSurf = render.coordText.render(coord_s, False, (1, 1, 1))
         text_rect = TextSurf.get_rect(center=(x, y))
-        cam.WORLD_SURFACES.blit(TextSurf, text_rect)
+
+        
+        tl = text_rect.topleft
+        imgw,imgh = TextSurf.get_size()
+        tlx,tly = tl
+        brx = tlx + imgw
+        wc = 0
+        ctlx = tlx
+        prev_w = 0
+        for surface in cam.WORLD_SURFACES:
+            w_surf, _ = surface.get_size()
+            xf = wc + w_surf
+            cbrx = min(xf,brx)
+            if ctlx != cbrx and ctlx <= xf:
+                tlx_p = ctlx - wc
+
+                w_sub_img = min(xf-ctlx,brx-ctlx)
+                proper_rect = pg.Rect((prev_w, 0),(w_sub_img,imgh))
+                sub_surf = TextSurf.subsurface(proper_rect)
+
+                surface.blit(sub_surf,(tlx_p,tly))
+
+                prev_w += w_sub_img
+                ctlx = cbrx
+            wc = xf
+
+       # cam.WORLD_SURFACES.blit(TextSurf, text_rect)
 
     def get_image_for_display(self, game, img="dark_blue_hex_and_border.png"):
         r = game.Renderer
@@ -206,13 +233,6 @@ class Hex:
 
         return loaded_image, dest
 
-    # def draw_tile_images_to_display(self, game):
-    #     rend = game.Renderer
-    #     camera = rend.camera
-    #     display = camera.surface
-    #     for image in self.images:
-    #         asset, dest = self.get_image_for_display(game, img=image)
-    #         display.blit(asset, dest)
 
     def get_image_for_world(self, game, img="dark_blue_hex_and_border.png"):
         r = game.Renderer
@@ -235,17 +255,30 @@ class Hex:
         camera = rend.camera
         surfaces = camera.WORLD_SURFACES
 
+        # TODO, switch loop to do blits instead of blit
         for image in self.images:
             img, tl = self.get_image_for_world(game,img=image)
+            imgw,imgh = img.get_size()
             tlx,tly = tl
+            brx = tlx + imgw
             wc = 0
-            cx = tlx
+            ctlx = tlx
+            prev_w = 0
             for surface in surfaces:
-                w_surf, h_surf = surface.get_size()
+                w_surf, _ = surface.get_size()
                 xf = wc + w_surf
-                if cx <= xf:
-                    tlx_p = cx - wc
-                    surface.blit(img,(tlx_p,tly))
+                cbrx = min(xf,brx)
+                if ctlx != cbrx and ctlx <= xf:
+                    tlx_p = ctlx - wc
+
+                    w_sub_img = min(xf-ctlx,brx-ctlx)
+                    proper_rect = pg.Rect((prev_w, 0),(w_sub_img,imgh))
+                    sub_surf = img.subsurface(proper_rect)
+
+                    surface.blit(sub_surf,(tlx_p,tly))
+
+                    prev_w += w_sub_img
+                    ctlx = cbrx
                 wc = xf
 
         #asset_dest_pairs = [self.get_image_for_world(game,img=image) for image in self.images]

--- a/Uncivilization/Hex.py
+++ b/Uncivilization/Hex.py
@@ -196,10 +196,9 @@ class Hex:
         TextSurf = render.coordText.render(coord_s, False, (1, 1, 1))
         text_rect = TextSurf.get_rect(center=(x, y))
 
-        
         tl = text_rect.topleft
-        imgw,imgh = TextSurf.get_size()
-        tlx,tly = tl
+        imgw, imgh = TextSurf.get_size()
+        tlx, tly = tl
         brx = tlx + imgw
         wc = 0
         ctlx = tlx
@@ -207,21 +206,21 @@ class Hex:
         for surface in cam.WORLD_SURFACES:
             w_surf, _ = surface.get_size()
             xf = wc + w_surf
-            cbrx = min(xf,brx)
+            cbrx = min(xf, brx)
             if ctlx != cbrx and ctlx <= xf:
                 tlx_p = ctlx - wc
 
-                w_sub_img = min(xf-ctlx,brx-ctlx)
-                proper_rect = pg.Rect((prev_w, 0),(w_sub_img,imgh))
+                w_sub_img = min(xf - ctlx, brx - ctlx)
+                proper_rect = pg.Rect((prev_w, 0), (w_sub_img, imgh))
                 sub_surf = TextSurf.subsurface(proper_rect)
 
-                surface.blit(sub_surf,(tlx_p,tly))
+                surface.blit(sub_surf, (tlx_p, tly))
 
                 prev_w += w_sub_img
                 ctlx = cbrx
             wc = xf
 
-       # cam.WORLD_SURFACES.blit(TextSurf, text_rect)
+    # cam.WORLD_SURFACES.blit(TextSurf, text_rect)
 
     def get_image_for_display(self, game, img="dark_blue_hex_and_border.png"):
         r = game.Renderer
@@ -233,7 +232,6 @@ class Hex:
         dest = (x0 - img_w / 2, y0 - img_h / 2)
 
         return loaded_image, dest
-
 
     def get_image_for_world(self, game, img="dark_blue_hex_and_border.png"):
         r = game.Renderer
@@ -258,9 +256,9 @@ class Hex:
         if not self.is_void:
             # TODO, switch loop to do blits instead of blit
             for image in self.images:
-                img, tl = self.get_image_for_world(game,img=image)
-                imgw,imgh = img.get_size()
-                tlx,tly = tl
+                img, tl = self.get_image_for_world(game, img=image)
+                imgw, imgh = img.get_size()
+                tlx, tly = tl
                 brx = tlx + imgw
                 wc = 0
                 ctlx = tlx
@@ -268,19 +266,19 @@ class Hex:
                 for surface in surfaces:
                     w_surf, _ = surface.get_size()
                     xf = wc + w_surf
-                    cbrx = min(xf,brx)
+                    cbrx = min(xf, brx)
                     if ctlx != cbrx and ctlx <= xf:
                         tlx_p = ctlx - wc
 
-                        w_sub_img = min(xf-ctlx,brx-ctlx)
-                        proper_rect = pg.Rect((prev_w, 0),(w_sub_img,imgh))
+                        w_sub_img = min(xf - ctlx, brx - ctlx)
+                        proper_rect = pg.Rect((prev_w, 0), (w_sub_img, imgh))
                         sub_surf = img.subsurface(proper_rect)
 
-                        surface.blit(sub_surf,(tlx_p,tly))
+                        surface.blit(sub_surf, (tlx_p, tly))
 
                         prev_w += w_sub_img
                         ctlx = cbrx
                     wc = xf
 
-        #asset_dest_pairs = [self.get_image_for_world(game,img=image) for image in self.images]
-        #camera.WORLD_SURFACES.blits(asset_dest_pairs)
+        # asset_dest_pairs = [self.get_image_for_world(game,img=image) for image in self.images]
+        # camera.WORLD_SURFACES.blits(asset_dest_pairs)

--- a/Uncivilization/Hex.py
+++ b/Uncivilization/Hex.py
@@ -161,6 +161,7 @@ class Hex:
             self.cube = cube
         self.images = images
         self.boarder_img = "outline_hex.png"
+        self.is_void = False
 
     def get_corner(self, center, size, index):
         angle_deg = 60 * index - 30
@@ -254,32 +255,32 @@ class Hex:
         rend = game.Renderer
         camera = rend.camera
         surfaces = camera.WORLD_SURFACES
+        if not self.is_void:
+            # TODO, switch loop to do blits instead of blit
+            for image in self.images:
+                img, tl = self.get_image_for_world(game,img=image)
+                imgw,imgh = img.get_size()
+                tlx,tly = tl
+                brx = tlx + imgw
+                wc = 0
+                ctlx = tlx
+                prev_w = 0
+                for surface in surfaces:
+                    w_surf, _ = surface.get_size()
+                    xf = wc + w_surf
+                    cbrx = min(xf,brx)
+                    if ctlx != cbrx and ctlx <= xf:
+                        tlx_p = ctlx - wc
 
-        # TODO, switch loop to do blits instead of blit
-        for image in self.images:
-            img, tl = self.get_image_for_world(game,img=image)
-            imgw,imgh = img.get_size()
-            tlx,tly = tl
-            brx = tlx + imgw
-            wc = 0
-            ctlx = tlx
-            prev_w = 0
-            for surface in surfaces:
-                w_surf, _ = surface.get_size()
-                xf = wc + w_surf
-                cbrx = min(xf,brx)
-                if ctlx != cbrx and ctlx <= xf:
-                    tlx_p = ctlx - wc
+                        w_sub_img = min(xf-ctlx,brx-ctlx)
+                        proper_rect = pg.Rect((prev_w, 0),(w_sub_img,imgh))
+                        sub_surf = img.subsurface(proper_rect)
 
-                    w_sub_img = min(xf-ctlx,brx-ctlx)
-                    proper_rect = pg.Rect((prev_w, 0),(w_sub_img,imgh))
-                    sub_surf = img.subsurface(proper_rect)
+                        surface.blit(sub_surf,(tlx_p,tly))
 
-                    surface.blit(sub_surf,(tlx_p,tly))
-
-                    prev_w += w_sub_img
-                    ctlx = cbrx
-                wc = xf
+                        prev_w += w_sub_img
+                        ctlx = cbrx
+                    wc = xf
 
         #asset_dest_pairs = [self.get_image_for_world(game,img=image) for image in self.images]
         #camera.WORLD_SURFACES.blits(asset_dest_pairs)

--- a/Uncivilization/Hex.py
+++ b/Uncivilization/Hex.py
@@ -175,7 +175,7 @@ class Hex:
         q, r = self.v
         render = game.Renderer
         cam = render.camera
-        origin = cam.AXIAL_ORIGIN
+        origin = cam.AXIAL_ORIGIN_PIXEL
 
         x, y = axial_to_pixel(game, self.v)
         x = x + origin[0]
@@ -220,7 +220,7 @@ class Hex:
         assets = r.assets["base_hexes"]
         cam = r.camera
 
-        origin = cam.AXIAL_ORIGIN
+        origin = cam.AXIAL_ORIGIN_PIXEL
 
         loaded_image = assets[img]
         img_w, img_h = loaded_image.get_size()

--- a/Uncivilization/MapNameToInstructions.py
+++ b/Uncivilization/MapNameToInstructions.py
@@ -22,12 +22,23 @@ def convert_alphas(r):
 def convert_hexes_and_set_camera(game):
     t0 = time.time()
     r = game.Renderer
+    play_rows, play_cols = game.GameState.playable_grid_size
     rows, cols = game.GameState.grid_size
 
     convert_alphas(r)
 
     hex_asset_size = r.assets["base_hex_size"]
-    game.Renderer.camera = Camera(hex_asset_size, r.width, r.height, rows, cols, n_max=14, n_min=4)
+    game.Renderer.camera = Camera(
+        hex_asset_size, 
+        r.width,
+        r.height,
+        rows,
+        cols,
+        play_rows,
+        play_cols,
+        n_max=14,
+        n_min=4
+    )
 
     dt = time.time() - t0
     dt = format(1000 * dt, "0.2f")
@@ -101,8 +112,8 @@ def draw_random_dots(game, rect, rect_color, timer, background_color=(0, 0, 0)):
 
 def random_tiles(game):
     state = game.GameState
-    grid = state.grid_size
-    rows, cols = grid
+    original_rows, original_cols = state.playable_grid_size
+    rows,cols = state.grid_size
 
     imgs = [
         "red",
@@ -128,25 +139,8 @@ def random_tiles(game):
             tile = Hex(cube=cube, images=[img])
             # tile = Hex(cube=cube, images=["red_hex_and_border.png"])
             q, r = tile.v
-
+            tile.is_void = True if abs(row) > original_rows or abs(col) > original_cols else False
             state.board.update({f"{q},{r}": tile})
-
-    # actual_rows = rows + 1 if rows % 2 == 0 else rows
-    # row_extrema_num = rows//2
-    # for row in range(-row_extrema_num,row_extrema_num + 1):
-    #     for col in range(-cols, cols + 1, 2):
-    #         cube = doubled_to_cube(row, col)
-    #         col_corrected,row_corrected = cube_to_doubled(cube)
-    #         # ^ doubled coord weirdness
-    #         if abs(col_corrected) <= cols:
-    #             #img = random.choice(imgs)
-    #             #img = f"{img}_hex_and_border.png"
-    #             #tile = Hex(cube=cube, images=[img])
-    #             tile = Hex(cube=cube, images=["red_hex_and_border.png"])
-    #             q, r = tile.v
-
-    #             state.board.update({f"{q},{r}": tile})
-
 
 MAP_TO_FUNC = {"random": random_tiles}
 

--- a/Uncivilization/MapNameToInstructions.py
+++ b/Uncivilization/MapNameToInstructions.py
@@ -29,15 +29,7 @@ def convert_hexes_and_set_camera(game):
 
     hex_asset_size = r.assets["base_hex_size"]
     game.Renderer.camera = Camera(
-        hex_asset_size, 
-        r.width,
-        r.height,
-        rows,
-        cols,
-        play_rows,
-        play_cols,
-        n_max=14,
-        n_min=4
+        hex_asset_size, r.width, r.height, rows, cols, play_rows, play_cols, n_max=14, n_min=4
     )
 
     dt = time.time() - t0
@@ -113,7 +105,7 @@ def draw_random_dots(game, rect, rect_color, timer, background_color=(0, 0, 0)):
 def random_tiles(game):
     state = game.GameState
     original_rows, original_cols = state.playable_grid_size
-    rows,cols = state.grid_size
+    rows, cols = state.grid_size
 
     imgs = [
         "red",
@@ -141,6 +133,7 @@ def random_tiles(game):
             q, r = tile.v
             tile.is_void = True if abs(row) > original_rows or abs(col) > original_cols else False
             state.board.update({f"{q},{r}": tile})
+
 
 MAP_TO_FUNC = {"random": random_tiles}
 


### PR DESCRIPTION
A single pygame surface can only be 2GB in size. For a 4x game in pygame to run smoothly the entire world (or at least most of it) must be loaded into memory beforehand. This means if we use one surface we are limited to a 2GB map despite a compute with more processing power. We should partition the world surface into several sub surfaces no larger than 1GB to combat this.